### PR TITLE
Edited examples/helloworld_rx/helloworld_rx.pde via GitHub

### DIFF
--- a/examples/helloworld_rx/helloworld_rx.pde
+++ b/examples/helloworld_rx/helloworld_rx.pde
@@ -12,7 +12,8 @@
  * RECEIVER NODE
  * Listens for messages from the transmitter and prints them out.
  */
-
+#include <stddef.h>
+#include <avr/pgmspace.h>
 #include <RF24Network.h>
 #include <RF24.h>
 #include <SPI.h>


### PR DESCRIPTION
In file included from helloworld_rx.cpp:16:
C:\arduino-0022\libraries\RF24Network/RF24Network.h:135: error: 'size_t' does not name a type
C:\arduino-0022\libraries\RF24Network/RF24Network.h:147: error: 'size_t' has not been declared
In file included from helloworld_rx.cpp:17:
C:\arduino-0022\libraries\RF24/RF24.h:175: error: 'prog_char' has not been declared
C:\arduino-0022\libraries\RF24/RF24.h:188: error: 'prog_char' has not been declared
helloworld_rx.cpp: In function 'void loop()':
helloworld_rx:52: error: 'class RF24Network' has no member named 'read'
